### PR TITLE
Choose model in zsh via environment variable

### DIFF
--- a/llm_cmd_comp/share/llm-cmd-comp.zsh
+++ b/llm_cmd_comp/share/llm-cmd-comp.zsh
@@ -5,7 +5,7 @@ __llm_cmdcomp() {
   local old_cmd=$BUFFER
   local cursor_pos=$CURSOR
   echo # Start the program on a blank line
-  local result=$(llm cmdcomp "$old_cmd")
+  local result=$(llm cmdcomp ${LLMCMDCOMP_MODEL:+-m$LLMCMDCOMP_MODEL} "$old_cmd")
   if [ $? -eq 0 ] && [ ! -z "$result" ]; then
     BUFFER=$result
   else


### PR DESCRIPTION
Optionally allow choosing the model in zsh by setting the environment variable LLMCMDCOMP_MODEL. 

This allows you to set the model llm cmd uses independently of the default model set in the llm tool.

I typically want a faster or different model for llm cmdcomp than when I use llm directly or other commands that use llm which use the defaults.